### PR TITLE
Feature/model integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ php:
 
 before_script:
     - composer install
-#    - mysql -e 'create database dsql_test;'
+    - mysql -e 'create database test3;'
 
 after_script:
     - echo $TRAVIS_PHP_VERSION
@@ -22,18 +22,3 @@ script:
 cache:
   directories:
     - $HOME/.composer/cache
-
-notifications:
-    slack:
-        rooms:
-            - agiletoolkit:bjrKuPBf1h4cYiNxPBQ1kF6c#dsql
-        on_success: change
-
-    urls:
-      - https://webhooks.gitter.im/e/b33a2db0c636f34bafa9
-
-    on_success: change  # options: [always|never|change] default: always
-    on_failure: always  # options: [always|never|change] default: always
-    on_start: never     # options: [always|never|change] default: always
-
-    email: false

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,10 @@
         "atk4/dsql": "dev-develop",
         "atk4/core": "dev-develop"
     },
+    "suggest": {
+        "atk4/data": "*",
+        "jdorn/sql-formatter": "*"
+    },
     "require-dev": {
         "phpunit/phpunit": "<6",
         "atk4/data": "dev-develop",

--- a/demos/init.php
+++ b/demos/init.php
@@ -1,0 +1,5 @@
+<?php
+include '../vendor/autoload.php';
+$db = \atk4\data\Persistence::connect('mysql://root:root@localhost/test');
+
+$db->connection = new \atk4\dsql\Connection_Dumper(['connection'=>$db->connection]);

--- a/demos/modelmigrator.php
+++ b/demos/modelmigrator.php
@@ -1,0 +1,27 @@
+<?php
+include 'init.php';
+
+class User extends \atk4\data\Model {
+    function init() {
+        parent::init();
+
+        $this->addField('name');
+    }
+}
+
+$m = new User($db, 'user');
+
+try {
+    // apply migrator
+    (new \atk4\schema\Migration\MySQL($m))->migrate();
+
+
+    // ok, now we surely have DB!
+
+
+    $m->save([
+        'name'=>'John'.rand(1,100)
+    ]);
+} catch (\atk4\core\Exception $e) {
+    echo $e->getColorfulText();
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <phpunit colors="true" bootstrap="vendor/autoload.php" printerClass="atk4\core\PHPUnit_AgileResultPrinter">
     <php>
-        <env name="DSN" value="mysql://root@localhost/test3" />
+        <env name="DSN" value="mysql://root:@localhost/test3" />
     </php>
     <filter>
         <blacklist>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <phpunit colors="true" bootstrap="vendor/autoload.php" printerClass="atk4\core\PHPUnit_AgileResultPrinter">
     <php>
-        <env name="DSN" value="mysql://root:root@localhost/test3" />
+        <env name="DSN" value="mysql://root@localhost/test3" />
     </php>
     <filter>
         <blacklist>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,9 +1,6 @@
 <phpunit colors="true" bootstrap="vendor/autoload.php" printerClass="atk4\core\PHPUnit_AgileResultPrinter">
     <php>
-        <var name="DB_DSN" value="sqlite::memory:" />
-        <var name="DB_USER" value="travis" />
-        <var name="DB_PASSWD" value="" />
-        <var name="DB_DBNAME" value="dsql_test" />
+        <env name="DSN" value="mysql://root:root@localhost/test3" />
     </php>
     <filter>
         <blacklist>

--- a/src/Migration.php
+++ b/src/Migration.php
@@ -18,7 +18,7 @@ class Migration extends Expression
     ];
 
     /** @var \atk4\dsql\Connection Database connection */
-    protected $connection;
+    public $connection;
 
     /**
      * Create new migration.

--- a/src/Migration.php
+++ b/src/Migration.php
@@ -224,14 +224,17 @@ class Migration extends Expression
      * Create rough model from current set of $this->args['fields']. This is not
      * ideal solution but is designed as a drop-in solution.
      */
-    public function createModel(\atk4\data\Persintence $persistence, $table = null)
+    public function createModel($persistence, $table = null)
     {
-        $m = new \atk4\data\Model($persistence);
-        if ($table) {
-            $m->table = $table;
-        }
+        $m = new \atk4\data\Model([$persistence, 'table'=>$table ?: $this['table'] = $table]);
 
-        foreach ($this->args['field'] as $field => $options) {
+        foreach ($this->_getFields() as $field => $options) {
+
+            if($field=='id')continue;
+
+            if(is_object($options)) {
+                continue;
+            }
 
             $defaults = [];
 
@@ -287,8 +290,31 @@ class Migration extends Expression
                 $type = null;
             }
 
+            if (substr($type, 0,4) == 'char') {
+                $type = null;
+            }
+            if (substr($type, 0,4) == 'enum') {
+                $type = null;
+            }
+
             if ($type == 'int') {
                 $type = 'integer';
+            }
+
+            if ($type == 'decimal') {
+                $type = 'integer';
+            }
+
+            if ($type == 'tinyint') {
+                $type = 'boolean';
+            }
+
+            if ($type == 'longtext') {
+                $type = 'text';
+            }
+
+            if ($type == 'longblob') {
+                $type = 'text';
             }
 
             $this->field($row['name'], ['type'=>$type]);

--- a/src/Migration/MySQL.php
+++ b/src/Migration/MySQL.php
@@ -11,13 +11,17 @@ class MySQL extends \atk4\schema\Migration
             return []; // no such table
         }
 
+        $result = [];
+
         foreach ($this->connection->expr('describe {}', [$table]) as $row) {
             $row2 = [];
             $row2['name'] = $row['Field'];
             $row2['pk'] = $row['Key'] == 'PRI';
+            $row2['type'] = preg_replace('/\(.*/','', $row['Type']);
 
-
-            var_dump($row);
+            $result[] = $row2;
         }
+
+        return $result;
     }
 }

--- a/src/Migration/MySQL.php
+++ b/src/Migration/MySQL.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace atk4\schema\Migration;
+
+class MySQL extends \atk4\schema\Migration
+{
+    public $primary_key_expr = 'integer primary key auto_increment';
+
+    public function describeTable($table) {
+        if (!$this->connection->expr('show tables like []', [$table])->get()) {
+            return []; // no such table
+        }
+
+        foreach ($this->connection->expr('describe {}', [$table]) as $row) {
+            $row2 = [];
+            $row2['name'] = $row['Field'];
+            $row2['pk'] = $row['Key'] == 'PRI';
+
+
+            var_dump($row);
+        }
+    }
+}

--- a/src/Migration/SQLite.php
+++ b/src/Migration/SQLite.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace atk4\schema\Migration;
+
+class SQLite extends \atk4\schema\Migration
+{
+    public $primary_key_expr = 'integer primary key autoincrement';
+
+    public function describeTable($table) {
+        return $this->connection->expr('pragma table_info({})', [$table])->get();
+    }
+}

--- a/src/PHPUnit_SchemaTestCase.php
+++ b/src/PHPUnit_SchemaTestCase.php
@@ -29,7 +29,7 @@ class PHPUnit_SchemaTestCase extends \atk4\core\PHPUnit_AgileTestCase
 
         // create databases
         foreach ($db_data as $table => $data) {
-            $s = new Migration(['connection' => $this->db->connection]);
+            $s = new Migration($this->db->connection);
             $s->table($table)->drop();
 
             $first_row = current($data);

--- a/src/PHPUnit_SchemaTestCase.php
+++ b/src/PHPUnit_SchemaTestCase.php
@@ -19,7 +19,6 @@ class PHPUnit_SchemaTestCase extends \atk4\core\PHPUnit_AgileTestCase
         parent::setUp();
         // establish connection
         $dsn = getenv('DSN');
-        var_Dump($dsn);
         if ($dsn) {
             $this->db = Persistence::connect(($this->debug ? ('dumper:') : '').$dsn);
             list($this->mode, $junk) = explode(':', $dsn, 2);

--- a/src/PHPUnit_SchemaTestCase.php
+++ b/src/PHPUnit_SchemaTestCase.php
@@ -2,7 +2,7 @@
 
 namespace atk4\schema;
 
-use atk4\data\Persistence_SQL;
+use atk4\data\Persistence;
 use atk4\dsql\Query;
 
 class PHPUnit_SchemaTestCase extends \atk4\core\PHPUnit_AgileTestCase
@@ -13,11 +13,39 @@ class PHPUnit_SchemaTestCase extends \atk4\core\PHPUnit_AgileTestCase
 
     public $debug = false;
 
+    public $mode = 'sqlite';
+
     public function setUp()
     {
         parent::setUp();
         // establish connection
-        $this->db = new Persistence_SQL(($this->debug ? ('dumper:') : '').'sqlite::memory:');
+        $dsn = getenv('DSN');
+        if ($dsn) {
+            $this->db = Persistence::connect(($this->debug ? ('dumper:') : '').$dsn);
+            list($this->mode, $junk) = explode(':', $dsn, 2);
+        } else {
+            $this->db = Persistence::connect(($this->debug ? ('dumper:') : '').'sqlite::memory:');
+        }
+    }
+
+    public function getMigration($m = null)
+    {
+        if ($this->mode == 'sqlite') {
+            return new \atk4\schema\Migration\SQLite($m ?: $this->db);
+        } elseif ($this->mode == 'mysql') {
+            return new \atk4\schema\Migration\MySQL($m ?: $this->db);
+        } else {
+            throw new \atk4\core\Exception(['Not sure which migration class to use for your DSN', 'mode'=>$this->mode, 'dsn'=>getenv('DSN')]);
+        }
+    }
+
+    /**
+     * Use this method to clean up tables after you have created them,
+     * so that your database would be ready for the next test
+     */
+    public function dropTable($table)
+    {
+        $this->db->connection->expr("drop table if exists {}", [$table])->execute();
     }
 
     /**
@@ -29,7 +57,7 @@ class PHPUnit_SchemaTestCase extends \atk4\core\PHPUnit_AgileTestCase
 
         // create databases
         foreach ($db_data as $table => $data) {
-            $s = new Migration($this->db->connection);
+            $s = $this->getMigration();
             $s->table($table)->drop();
 
             $first_row = current($data);

--- a/src/PHPUnit_SchemaTestCase.php
+++ b/src/PHPUnit_SchemaTestCase.php
@@ -3,7 +3,6 @@
 namespace atk4\schema;
 
 use atk4\data\Persistence;
-use atk4\dsql\Query;
 
 class PHPUnit_SchemaTestCase extends \atk4\core\PHPUnit_AgileTestCase
 {
@@ -85,7 +84,7 @@ class PHPUnit_SchemaTestCase extends \atk4\core\PHPUnit_AgileTestCase
             $has_id = (bool) key($data);
 
             foreach ($data as $id => $row) {
-                $s = new Query(['connection' => $this->db->connection]);
+                $s = $this->db->dsql(); //(['connection' => $this->db->connection]);
                 if ($id === '_') {
                     continue;
                 }
@@ -118,7 +117,7 @@ class PHPUnit_SchemaTestCase extends \atk4\core\PHPUnit_AgileTestCase
         foreach ($tables as $table) {
             $data2 = [];
 
-            $s = new Query(['connection' => $this->db->connection]);
+            $s = $this->db->dsql();
             $data = $s->table($table)->get();
 
             foreach ($data as &$row) {

--- a/src/PHPUnit_SchemaTestCase.php
+++ b/src/PHPUnit_SchemaTestCase.php
@@ -19,6 +19,7 @@ class PHPUnit_SchemaTestCase extends \atk4\core\PHPUnit_AgileTestCase
         parent::setUp();
         // establish connection
         $dsn = getenv('DSN');
+        var_Dump($dsn);
         if ($dsn) {
             $this->db = Persistence::connect(($this->debug ? ('dumper:') : '').$dsn);
             list($this->mode, $junk) = explode(':', $dsn, 2);
@@ -84,7 +85,7 @@ class PHPUnit_SchemaTestCase extends \atk4\core\PHPUnit_AgileTestCase
             $has_id = (bool) key($data);
 
             foreach ($data as $id => $row) {
-                $s = $this->db->dsql(); //(['connection' => $this->db->connection]);
+                $s = $this->db->dsql();
                 if ($id === '_') {
                     continue;
                 }

--- a/tests/BasicTest.php
+++ b/tests/BasicTest.php
@@ -2,7 +2,7 @@
 
 namespace atk4\ui\tests;
 
-class BasicTest extends \atk4\core\PHPUnit_AgileTestCase //class BasicTest extends \atk4\core\PHPUnit_AgileTestCase
+class BasicTest extends \atk4\core\PHPUnit_AgileTestCase
 {
     /**
      * Test constructor.

--- a/tests/BasicTest.php
+++ b/tests/BasicTest.php
@@ -2,13 +2,34 @@
 
 namespace atk4\ui\tests;
 
-class BasicTest extends \atk4\core\PHPUnit_AgileTestCase
+use \atk4\schema\Migration\SQLite as Migration;
+
+class BasicTest extends \atk4\schema\PHPUnit_SchemaTestCase
 {
     /**
      * Test constructor.
      */
-    public function testTesting()
+    public function testCreateAndAlter()
     {
-        $this->assertEquals('foo', 'foo');
+        $this->dropTable('user');
+        $m = $this->getMigration();
+        $m->table('user')->id()->field('foo')->field('bar', ['type'=>'integer'])->field('baz', ['type'=>'text'])->create();
+
+        $m = $this->getMigration();
+        $m->table('user')->newField('zed', ['type'=>'integer'])->alter();
+    }
+
+    public function testCreateAndDrop()
+    {
+        if ($this->mode == 'sqlite') {
+            $this->markTestSkipped('SQLite does not support drop');
+        }
+
+        $this->dropTable('user');
+        $m = $this->getMigration();
+        $m->table('user')->id()->field('foo')->field('bar', ['type'=>'integer'])->field('baz', ['type'=>'text'])->create();
+
+        $m = $this->getMigration();
+        $m->table('user')->dropField('bar', ['type'=>'integer'])->alter();
     }
 }

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -2,15 +2,16 @@
 
 namespace atk4\schema\tests;
 
-use \atk4\schema\Migration;
+use \atk4\schema\Migration\SQLite as Migration;
 
 class ModelTest extends \atk4\schema\PHPUnit_SchemaTestCase
 {
     public function testSetModelCreate()
     {
+        $this->dropTable('user');
         $user = new Testuser($this->db);
 
-        $migration = new Migration($user);
+        $migration = $this->getMigration($user);
         $migration->create();
 
         // now we can use user
@@ -19,12 +20,12 @@ class ModelTest extends \atk4\schema\PHPUnit_SchemaTestCase
 
     public function testImportTable()
     {
-        //$user = new Testuser($this->db);
-        $m = new Migration($this->db);
+        $this->dropTable('user');
+        $m = $this->getMigration();
         $m->table('user')->id()->field('foo')->field('bar', ['type'=>'integer'])->field('baz', ['type'=>'text'])->create();
         $this->db->dsql()->table('user')->set('id', 1)->set('foo', 'foovalue')->set('bar', 123)->set('baz','long text value')->insert();
 
-        $m2 = new Migration($this->db);
+        $m2 = $this->getMigration();
         $m2->importTable('user');
 
         $m2->mode('create');
@@ -33,14 +34,13 @@ class ModelTest extends \atk4\schema\PHPUnit_SchemaTestCase
 
     public function testMigrateTable()
     {
-        //$user = new Testuser($this->db);
-        $m = new Migration($this->db);
+        $this->dropTable('user');
+        $m = $this->getMigration($this->db);
         $m->table('user')->id()->field('foo')->field('bar', ['type'=>'integer'])->field('baz', ['type'=>'text'])->create();
         $this->db->dsql()->table('user')->set('id', 1)->set('foo', 'foovalue')->set('bar', 123)->set('baz','long text value')->insert();
 
-        $m2 = new Migration($this->db);
+        $m2 = $this->getMigration($this->db);
         $m2->table('user')->id()->field('xx')->field('bar', ['type'=>'integer'])->field('baz')->migrate();
-        // field foo should be gone, xx should be added, bar should remain unchanged and baz should change from text to varchar
     }
 }
 

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace atk4\schema\tests;
+
+use \atk4\schema\Migration;
+
+class ModelTest extends \atk4\core\PHPUnit_SQLTestCase
+{
+    public $debug = true;
+
+    public function testSetModelCreate()
+    {
+        $user = new Testuser($this->db);
+
+        $migration = new Migration($user);
+        $migration->create();
+
+        // now we can use user
+        $user->save(['name'=>'john', 'is_admin'=>true, 'notes'=>'some long notes']);
+    }
+
+    public function testImportTable()
+    {
+        //$user = new Testuser($this->db);
+        $m = new Migration($this->db);
+        $m->table('user')->id()->field('foo')->field('bar', ['type'=>'integer'])->field('baz', ['type'=>'text'])->create();
+        $this->db->dsql()->table('user')->set('id', 1)->set('foo', 'foovalue')->set('bar', 123)->set('baz','long text value')->insert();
+
+        $m2 = new Migration($this->db);
+        $m2->importTable('user');
+
+        $m2->mode('create');
+        $this->assertEquals($m->getDebugQuery(), $m2->getDebugQuery());
+    }
+
+    public function testMigrateTable()
+    {
+        //$user = new Testuser($this->db);
+        $m = new Migration($this->db);
+        $m->table('user')->id()->field('foo')->field('bar', ['type'=>'integer'])->field('baz', ['type'=>'text'])->create();
+        $this->db->dsql()->table('user')->set('id', 1)->set('foo', 'foovalue')->set('bar', 123)->set('baz','long text value')->insert();
+
+        $m2 = new Migration($this->db);
+        $m2->table('user')->id()->field('xx')->field('bar', ['type'=>'integer'])->field('baz')->migrate();
+        // field foo should be gone, xx should be added, bar should remain unchanged and baz should change from text to varchar
+    }
+}
+
+class TestUser extends \atk4\data\Model {
+    public $table = 'user';
+
+    function init() {
+        parent::init();
+
+        $this->addField('name');
+        $this->addField('password', ['type'=>'password']);
+        $this->addField('is_admin', ['type'=>'boolean']);
+        $this->addField('notes', ['type'=>'text']);
+    }
+
+}

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -4,10 +4,8 @@ namespace atk4\schema\tests;
 
 use \atk4\schema\Migration;
 
-class ModelTest extends \atk4\core\PHPUnit_SQLTestCase
+class ModelTest extends \atk4\schema\PHPUnit_SchemaTestCase
 {
-    public $debug = true;
-
     public function testSetModelCreate()
     {
         $user = new Testuser($this->db);

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -49,11 +49,14 @@ done
 
 open "https://github.com/atk4/$product/compare/$prev_version...develop"
 
-# Update dependency versions
-sed -i "" -e '/atk4\/data/s/dev-develop/\*/' composer.json # workaround composers inability to change both requries simultaniously
-composer require atk4/core atk4/dsql
-
+# Tweak our json file
+sed -i "" -e '/atk4.*dev-develop/d' composer.json
+rm -rf vendor/atk4/
+#composer update
+composer require atk4/dsql atk4/core
+composer require --dev atk4/data
 composer update
+
 ./vendor/phpunit/phpunit/phpunit  --no-coverage
 
 echo "Press enter to publish the release"


### PR DESCRIPTION
Schema migration class should be friendly with Agile Data. This PR adds the following features:

 - $migration->fromModel($m) - read table schema from a model
 - $migration->fromTable($table) - read table schema from SQL table
 - $migration->exportModel() - create quick'n'dirty model object for current migration
 - $migration->migrate() - compare current migration with actual data and alter
 - composer now recommend atk4/data


How to use:

``` php
$m = new Migration(new User($db));
$m->migrate(); // make sure table for User exists and has correct fields.

// or

$m = new Migration($db);
$m->fromTable('stats');
$app->add('CRUD')->setModel($m->exportModel());
```